### PR TITLE
Refactor to send delivery object value instead of pointer

### DIFF
--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -1,8 +1,12 @@
 package EventPeople
 
 import (
+    "sync"
+
 	amqp "github.com/rabbitmq/amqp091-go"
 )
+
+var mutex sync.Mutex
 
 type RabbitContext struct {
     ContextInterface
@@ -15,18 +19,22 @@ func (context *RabbitContext) Initialize(delivery *amqp.Delivery) {
 
 func (context *RabbitContext) Success() {
     context.delivery.Ack(false)
+    mutex.Unlock()
 }
 
 func (context *RabbitContext) Fail() {
     context.delivery.Nack(false, true)
+    mutex.Unlock()
 }
 
 func (context *RabbitContext) Reject() {
     context.delivery.Reject(false)
+    mutex.Unlock()
 }
 
 func NewContext(delivery *amqp.Delivery) *RabbitContext {
     context := new(RabbitContext)
     context.Initialize(delivery)
+    mutex.Lock()
     return context
 }

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -1,8 +1,6 @@
 package EventPeople
 
 import (
-    "sync"
-
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -6,35 +6,29 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-var mutex sync.Mutex
-
 type RabbitContext struct {
     ContextInterface
-    delivery *amqp.Delivery
+    delivery amqp.Delivery
 }
 
-func (context *RabbitContext) Initialize(delivery *amqp.Delivery) {
+func (context *RabbitContext) Initialize(delivery amqp.Delivery) {
     context.delivery = delivery
 }
 
 func (context *RabbitContext) Success() {
     context.delivery.Ack(false)
-    mutex.Unlock()
 }
 
 func (context *RabbitContext) Fail() {
     context.delivery.Nack(false, true)
-    mutex.Unlock()
 }
 
 func (context *RabbitContext) Reject() {
     context.delivery.Reject(false)
-    mutex.Unlock()
 }
 
-func NewContext(delivery *amqp.Delivery) *RabbitContext {
+func NewContext(delivery amqp.Delivery) *RabbitContext {
     context := new(RabbitContext)
     context.Initialize(delivery)
-    mutex.Lock()
     return context
 }

--- a/lib/event_people/rabbit_queue.go
+++ b/lib/event_people/rabbit_queue.go
@@ -50,7 +50,7 @@ func (queue *Queue) callback(deliveries <-chan amqp.Delivery, callback Callback)
 		eventMessage.Name = eventMessage.Headers.AppName
 		eventMessage.SchemaVersion = eventMessage.Headers.SchemaVersion
 
-		callback(eventMessage, NewContext(&delivery))
+		callback(eventMessage, NewContext(delivery))
 	}
 }
 


### PR DESCRIPTION
## Problem
_What problem are you trying to solve?_
When processing multiple events at the same time the lib was causing an application to have unpredictable behavior, because the `delivery` object was being passed as a pointer to all workers and eventually being replacing the object on the memory address, causing a worker to signal the wrong job as finished.

## Solution
_How did you solve the problem?_
Instead of sharing the `delivery` object memory address, we now pass its value to the worker, which is more secure and thread safe.