### PR TITLE
[sc-22500] DLQ + bounded retry (poison message protection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ We follow the RabbitMQ pattern matching model, so given each word of the event n
 Other important aspect of event consumming is the result of the processing we provide 3 methods so you can inform the Broker what to do with the event next:
 
 -   `Success:` should be called when the event was processed successfuly and the can be discarded;
--   `Fail:` should be called when an error ocurred processing the event and the message should be requeued;
--   `Reject:` should be called whenever a message should be discarded without being processed.
+-   `Fail:` should be called on transient errors (database down, timeouts). The message is retried a bounded number of times and then dead-lettered — see [Failure handling, retries and the DLQ](#failure-handling-retries-and-the-dlq);
+-   `Reject:` should be called on deterministic errors (validation, malformed payload). The message goes straight to the Dead Letter Queue without being retried.
 
 Given you want to consume a single event inside your project you can use the `EventPeople.ListenTo` method. It consumes a single event, given there are events available to be consumed with the given name pattern.
 
@@ -355,6 +355,74 @@ func main() {
 ```
 
 [See more details](https://github.com/pin-people/event_people_node/blob/master/examples/daemon.rb)
+
+## Failure handling, retries and the DLQ
+
+Since v0.2.0 every queue is declared with dead-lettering enabled. No message is
+silently dropped or requeued forever.
+
+### Topology
+
+Declared automatically by `SubscribeTo`/`BindAllListeners` for each app
+(`RABBIT_EVENT_PEOPLE_APP_NAME=service` in the examples below):
+
+| Object | Name | Purpose |
+| --- | --- | --- |
+| Dead Letter Exchange (fanout, durable) | `service.dlx` | Receives every `Nack(requeue=false)`/`Reject(false)` |
+| Dead Letter Queue (durable) | `service.dlq` | Parking queue bound to the DLX; messages stay here until inspected/replayed |
+| Retry queue (durable, per main queue) | `<queue>.retry` | Holds retried messages for `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS`, then returns them to the original queue via the default exchange |
+
+Main queues are declared with `x-dead-letter-exchange: service.dlx`.
+
+### Semantics
+
+-   `context.Success()` — Ack. Unchanged.
+-   `context.Fail()` — bounded retry. The current attempt count is read from the
+    `x-event-people-retries` header; while below `RABBIT_EVENT_PEOPLE_MAX_RETRIES`
+    the message is republished to `<queue>.retry` (with the counter incremented)
+    and the original is acked. Once exhausted — or if republishing fails — the
+    message is `Nack(requeue=false)`ed and lands in the DLQ.
+-   `context.Reject()` — `Reject(requeue=false)`: straight to the DLQ. Use it for
+    deterministic errors (validation, unmarshal/encode) that would fail on every
+    retry. Never loops, never lost.
+
+### Configuration
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `RABBIT_EVENT_PEOPLE_MAX_RETRIES` | `3` | Retries before a `Fail()`ed message is dead-lettered |
+| `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS` | `30000` | Delay between retries (TTL of the retry queue) |
+
+### Rolling out to existing environments
+
+RabbitMQ refuses to redeclare an existing durable queue with different
+arguments (`PRECONDITION_FAILED`, channel closes). Queues created by versions
+before v0.2.0 have no `x-dead-letter-exchange`, so for each service:
+
+1. Stop the consumer.
+2. Make sure the queues are empty (drain or wait).
+3. Delete the service's queues (`rabbitmqadmin delete queue name=<queue>`).
+4. Deploy/start the consumer with v0.2.0 — queues are redeclared with the DLQ args.
+
+### Inspecting and replaying the DLQ
+
+Each dead-lettered message carries the standard `x-death` header (original
+queue, reason, count). To inspect without consuming:
+
+```cmd
+rabbitmqadmin get queue=service.dlq ackmode=reject_requeue_true count=10
+```
+
+To replay, republish the message to the default exchange using the original
+queue name (from `x-death`) as the routing key, then ack it in the DLQ.
+
+### Monitoring
+
+Alert on DLQ depth with the RabbitMQ Prometheus plugin:
+
+```promql
+rabbitmq_queue_messages{queue=~".*\\.dlq"} > 0
+```
 
 ## Development
 

--- a/lib/event_people/context.go
+++ b/lib/event_people/context.go
@@ -1,5 +1,7 @@
 package EventPeople
 
+import amqp "github.com/rabbitmq/amqp091-go"
+
 type ContextInterface interface {
 	Initialize(DeliveryInterface)
 	Success()
@@ -17,4 +19,7 @@ type DeliveryStruct struct {
 	DeliveryInterface
 	DeliveryTag uint64
 	Body        []byte
+	Headers     amqp.Table
+	QueueName   string
+	Publish     PublishFunc
 }

--- a/lib/event_people/delivery_job.go
+++ b/lib/event_people/delivery_job.go
@@ -19,6 +19,7 @@ func (j *Job) Do() {
 	eventMessage.Name = eventMessage.Headers.AppName
 	eventMessage.SchemaVersion = eventMessage.Headers.SchemaVersion
 
-	rabbitContext := NewContext(j.job.delivery.DeliveryInterface)
+	rabbitContext := NewContext(j.job.delivery.DeliveryInterface, j.job.delivery.Headers, j.job.delivery.QueueName, j.job.delivery.Publish)
+	rabbitContext.DeliveryStruct = *j.job.delivery
 	j.job.callback(eventMessage, rabbitContext)
 }

--- a/lib/event_people/dlq_config.go
+++ b/lib/event_people/dlq_config.go
@@ -1,0 +1,47 @@
+package EventPeople
+
+import (
+	"os"
+	"strconv"
+)
+
+const (
+	defaultMaxRetries = 3
+	defaultRetryTTLMs = 30000
+)
+
+// MaxRetries returns how many times a failed message is retried before
+// being dead-lettered. Configured via RABBIT_EVENT_PEOPLE_MAX_RETRIES.
+func MaxRetries() int {
+	value, err := strconv.Atoi(os.Getenv("RABBIT_EVENT_PEOPLE_MAX_RETRIES"))
+	if err != nil || value <= 0 {
+		return defaultMaxRetries
+	}
+	return value
+}
+
+// RetryTTLMs returns how long a message waits in the retry queue before
+// being redelivered. Configured via RABBIT_EVENT_PEOPLE_RETRY_TTL_MS.
+func RetryTTLMs() int64 {
+	value, err := strconv.ParseInt(os.Getenv("RABBIT_EVENT_PEOPLE_RETRY_TTL_MS"), 10, 64)
+	if err != nil || value <= 0 {
+		return defaultRetryTTLMs
+	}
+	return value
+}
+
+// DeadLetterExchangeName is the per-app fanout exchange that receives
+// rejected and retry-exhausted messages.
+func DeadLetterExchangeName() string {
+	return os.Getenv("RABBIT_EVENT_PEOPLE_APP_NAME") + ".dlx"
+}
+
+// DeadLetterQueueName is the per-app parking queue bound to the DLX.
+func DeadLetterQueueName() string {
+	return os.Getenv("RABBIT_EVENT_PEOPLE_APP_NAME") + ".dlq"
+}
+
+// RetryQueueName is the per-queue wait queue used for bounded retries.
+func RetryQueueName(queueName string) string {
+	return queueName + ".retry"
+}

--- a/lib/event_people/dlq_config_test.go
+++ b/lib/event_people/dlq_config_test.go
@@ -1,0 +1,60 @@
+package EventPeople
+
+import "testing"
+
+func TestMaxRetries(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset uses default", "", 3},
+		{"valid value", "5", 5},
+		{"garbage uses default", "abc", 3},
+		{"zero uses default", "0", 3},
+		{"negative uses default", "-2", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("RABBIT_EVENT_PEOPLE_MAX_RETRIES", tt.env)
+			if got := MaxRetries(); got != tt.want {
+				t.Errorf("MaxRetries() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryTTLMs(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int64
+	}{
+		{"unset uses default", "", 30000},
+		{"valid value", "5000", 5000},
+		{"garbage uses default", "abc", 30000},
+		{"zero uses default", "0", 30000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("RABBIT_EVENT_PEOPLE_RETRY_TTL_MS", tt.env)
+			if got := RetryTTLMs(); got != tt.want {
+				t.Errorf("RetryTTLMs() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeadLetterNames(t *testing.T) {
+	t.Setenv("RABBIT_EVENT_PEOPLE_APP_NAME", "sophia")
+
+	if got := DeadLetterExchangeName(); got != "sophia.dlx" {
+		t.Errorf("DeadLetterExchangeName() = %q, want %q", got, "sophia.dlx")
+	}
+	if got := DeadLetterQueueName(); got != "sophia.dlq" {
+		t.Errorf("DeadLetterQueueName() = %q, want %q", got, "sophia.dlq")
+	}
+	if got := RetryQueueName("sophia-resource.event.action.all"); got != "sophia-resource.event.action.all.retry" {
+		t.Errorf("RetryQueueName() = %q, want %q", got, "sophia-resource.event.action.all.retry")
+	}
+}

--- a/lib/event_people/rabbit_broker.go
+++ b/lib/event_people/rabbit_broker.go
@@ -92,14 +92,30 @@ func (rabbit *RabbitBroker) Consume(eventName string, callback Callback) {
 	if err != nil {
 		log.Println(err)
 	}
+	queueName := queue.queueNameByRoutingKey(eventName)
+	publish := func(routingKey string, headers amqp.Table, body []byte) error {
+		return channel.Publish("", routingKey, false, false, amqp.Publishing{
+			Headers:      headers,
+			ContentType:  "application/json",
+			DeliveryMode: amqp.Persistent,
+			Body:         body,
+		})
+	}
 	for delivery := range deliveries {
 		var eventMessage Event
 		json.Unmarshal(delivery.Body, &eventMessage)
 
 		eventMessage.Name = eventMessage.Headers.AppName
 		eventMessage.SchemaVersion = eventMessage.Headers.SchemaVersion
-		deliveryStruct := DeliveryStruct{DeliveryInterface: delivery, Body: delivery.Body, DeliveryTag: delivery.DeliveryTag}
-		rabbitContext := NewContext(delivery)
+		deliveryStruct := DeliveryStruct{
+			DeliveryInterface: delivery,
+			Body:              delivery.Body,
+			DeliveryTag:       delivery.DeliveryTag,
+			Headers:           delivery.Headers,
+			QueueName:         queueName,
+			Publish:           publish,
+		}
+		rabbitContext := NewContext(delivery, delivery.Headers, queueName, publish)
 		rabbitContext.DeliveryStruct = deliveryStruct
 		callback(eventMessage, rabbitContext)
 	}

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -1,9 +1,24 @@
 package EventPeople
 
+import (
+	"log"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// PublishFunc publishes a message body with headers to a routing key on
+// the default exchange. Used to send failed messages to the retry queue.
+type PublishFunc func(routingKey string, headers amqp.Table, body []byte) error
+
+const retriesHeader = "x-event-people-retries"
+
 type RabbitContext struct {
 	ContextInterface
 	delivery       DeliveryInterface
 	DeliveryStruct DeliveryStruct
+	headers        amqp.Table
+	queueName      string
+	publish        PublishFunc
 }
 
 func (context RabbitContext) Initialize(delivery DeliveryInterface) {
@@ -14,15 +29,58 @@ func (context RabbitContext) Success() {
 	context.delivery.Ack(false)
 }
 
+// Fail retries the message a bounded number of times by republishing it
+// to the retry queue, then dead-letters it once retries are exhausted or
+// republishing is not possible.
 func (context RabbitContext) Fail() {
-	context.delivery.Nack(false, true)
+	if context.publish == nil || context.retryCount() >= MaxRetries() {
+		context.deadLetter()
+		return
+	}
+
+	headers := amqp.Table{}
+	for key, value := range context.headers {
+		headers[key] = value
+	}
+	headers[retriesHeader] = int32(context.retryCount() + 1)
+
+	err := context.publish(RetryQueueName(context.queueName), headers, context.DeliveryStruct.Body)
+	if err != nil {
+		log.Printf("event_people: retry republish failed, dead-lettering: %v", err)
+		context.deadLetter()
+		return
+	}
+	context.delivery.Ack(false)
 }
 
 func (context RabbitContext) Reject() {
 	context.delivery.Reject(false)
 }
 
-func NewContext(delivery DeliveryInterface) *RabbitContext {
-	context := &RabbitContext{delivery: delivery}
-	return context
+// deadLetter routes the message to the DLQ via the queue's
+// x-dead-letter-exchange (Nack without requeue).
+func (context RabbitContext) deadLetter() {
+	context.delivery.Nack(false, false)
+}
+
+func (context RabbitContext) retryCount() int {
+	switch value := context.headers[retriesHeader].(type) {
+	case int32:
+		return int(value)
+	case int64:
+		return int(value)
+	case int:
+		return value
+	default:
+		return 0
+	}
+}
+
+func NewContext(delivery DeliveryInterface, headers amqp.Table, queueName string, publish PublishFunc) *RabbitContext {
+	return &RabbitContext{
+		delivery:  delivery,
+		headers:   headers,
+		queueName: queueName,
+		publish:   publish,
+	}
 }

--- a/lib/event_people/rabbit_context_test.go
+++ b/lib/event_people/rabbit_context_test.go
@@ -1,0 +1,152 @@
+package EventPeople
+
+import (
+	"errors"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type fakeDelivery struct {
+	acks    int
+	nacks   []bool // requeue flag per Nack call
+	rejects []bool // requeue flag per Reject call
+}
+
+func (f *fakeDelivery) Ack(bool) error { f.acks++; return nil }
+func (f *fakeDelivery) Nack(_ bool, requeue bool) error {
+	f.nacks = append(f.nacks, requeue)
+	return nil
+}
+func (f *fakeDelivery) Reject(requeue bool) error {
+	f.rejects = append(f.rejects, requeue)
+	return nil
+}
+
+type fakePublisher struct {
+	routingKeys []string
+	headers     []amqp.Table
+	bodies      [][]byte
+	err         error
+}
+
+func (f *fakePublisher) publish(routingKey string, headers amqp.Table, body []byte) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.routingKeys = append(f.routingKeys, routingKey)
+	f.headers = append(f.headers, headers)
+	f.bodies = append(f.bodies, body)
+	return nil
+}
+
+func newTestContext(delivery *fakeDelivery, publisher *fakePublisher, headers amqp.Table) *RabbitContext {
+	ctx := NewContext(delivery, headers, "sophia-resource.event.action.all", publisher.publish)
+	ctx.DeliveryStruct = DeliveryStruct{DeliveryInterface: delivery, Body: []byte(`{"k":"v"}`)}
+	return ctx
+}
+
+func TestSuccessAcks(t *testing.T) {
+	delivery := &fakeDelivery{}
+	ctx := newTestContext(delivery, &fakePublisher{}, nil)
+
+	ctx.Success()
+
+	if delivery.acks != 1 {
+		t.Fatalf("acks = %d, want 1", delivery.acks)
+	}
+}
+
+func TestRejectDeadLettersWithoutRequeue(t *testing.T) {
+	delivery := &fakeDelivery{}
+	ctx := newTestContext(delivery, &fakePublisher{}, nil)
+
+	ctx.Reject()
+
+	if len(delivery.rejects) != 1 || delivery.rejects[0] != false {
+		t.Fatalf("rejects = %v, want one Reject(requeue=false)", delivery.rejects)
+	}
+}
+
+func TestFailRepublishesToRetryQueueWhileUnderLimit(t *testing.T) {
+	tests := []struct {
+		name        string
+		headers     amqp.Table
+		wantRetries int32
+	}{
+		{"first failure, nil headers", nil, 1},
+		{"second failure", amqp.Table{"x-event-people-retries": int32(1)}, 2},
+		{"int64 header from broker", amqp.Table{"x-event-people-retries": int64(2)}, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delivery := &fakeDelivery{}
+			publisher := &fakePublisher{}
+			ctx := newTestContext(delivery, publisher, tt.headers)
+
+			ctx.Fail()
+
+			if len(publisher.routingKeys) != 1 || publisher.routingKeys[0] != "sophia-resource.event.action.all.retry" {
+				t.Fatalf("published to %v, want retry queue", publisher.routingKeys)
+			}
+			if got := publisher.headers[0]["x-event-people-retries"]; got != tt.wantRetries {
+				t.Errorf("retries header = %v, want %d", got, tt.wantRetries)
+			}
+			if string(publisher.bodies[0]) != `{"k":"v"}` {
+				t.Errorf("body = %s, want original body", publisher.bodies[0])
+			}
+			if delivery.acks != 1 {
+				t.Errorf("acks = %d, want 1 (original message acked after republish)", delivery.acks)
+			}
+			if len(delivery.nacks) != 0 {
+				t.Errorf("nacks = %v, want none", delivery.nacks)
+			}
+		})
+	}
+}
+
+func TestFailDeadLettersWhenRetriesExhausted(t *testing.T) {
+	delivery := &fakeDelivery{}
+	publisher := &fakePublisher{}
+	headers := amqp.Table{"x-event-people-retries": int32(3)}
+	ctx := newTestContext(delivery, publisher, headers)
+
+	ctx.Fail()
+
+	if len(publisher.routingKeys) != 0 {
+		t.Errorf("published %v, want no republish", publisher.routingKeys)
+	}
+	if len(delivery.nacks) != 1 || delivery.nacks[0] != false {
+		t.Fatalf("nacks = %v, want one Nack(requeue=false)", delivery.nacks)
+	}
+	if delivery.acks != 0 {
+		t.Errorf("acks = %d, want 0", delivery.acks)
+	}
+}
+
+func TestFailDeadLettersWhenRepublishFails(t *testing.T) {
+	delivery := &fakeDelivery{}
+	publisher := &fakePublisher{err: errors.New("channel closed")}
+	ctx := newTestContext(delivery, publisher, nil)
+
+	ctx.Fail()
+
+	if len(delivery.nacks) != 1 || delivery.nacks[0] != false {
+		t.Fatalf("nacks = %v, want one Nack(requeue=false) fallback", delivery.nacks)
+	}
+	if delivery.acks != 0 {
+		t.Errorf("acks = %d, want 0", delivery.acks)
+	}
+}
+
+func TestFailWithoutPublisherFallsBackToDeadLetter(t *testing.T) {
+	delivery := &fakeDelivery{}
+	ctx := NewContext(delivery, nil, "queue", nil)
+	ctx.DeliveryStruct = DeliveryStruct{DeliveryInterface: delivery, Body: []byte(`{}`)}
+
+	ctx.Fail()
+
+	if len(delivery.nacks) != 1 || delivery.nacks[0] != false {
+		t.Fatalf("nacks = %v, want one Nack(requeue=false)", delivery.nacks)
+	}
+}

--- a/lib/event_people/rabbit_queue.go
+++ b/lib/event_people/rabbit_queue.go
@@ -54,12 +54,41 @@ func (queue *Queue) QueueName(routingKey string) string {
 }
 
 func (queue *Queue) createQueue(queueName string) error {
-	localQueue, err := queue.channel.QueueDeclare(queueName, true, false, false, false, nil)
+	localQueue, err := queue.channel.QueueDeclare(queueName, true, false, false, false, mainQueueArgs())
 	if err != nil {
 		return err
 	}
 	queue.amqpQueue = &localQueue
 	return nil
+}
+
+func mainQueueArgs() amqp.Table {
+	return amqp.Table{"x-dead-letter-exchange": DeadLetterExchangeName()}
+}
+
+func retryQueueArgs(queueName string) amqp.Table {
+	return amqp.Table{
+		"x-message-ttl":             RetryTTLMs(),
+		"x-dead-letter-exchange":    "",
+		"x-dead-letter-routing-key": queueName,
+	}
+}
+
+func (queue *Queue) createDeadLetterTopology() error {
+	err := queue.channel.ExchangeDeclare(DeadLetterExchangeName(), "fanout", true, false, false, false, nil)
+	if err != nil {
+		return err
+	}
+	_, err = queue.channel.QueueDeclare(DeadLetterQueueName(), true, false, false, false, nil)
+	if err != nil {
+		return err
+	}
+	return queue.channel.QueueBind(DeadLetterQueueName(), "", DeadLetterExchangeName(), false, nil)
+}
+
+func (queue *Queue) createRetryQueue(queueName string) error {
+	_, err := queue.channel.QueueDeclare(RetryQueueName(queueName), true, false, false, false, retryQueueArgs(queueName))
+	return err
 }
 
 func (queue *Queue) inspectQueue(queueName string) error {
@@ -87,7 +116,15 @@ func (queue *Queue) exchangeBind(queueName string, routingKey string) error {
 
 func (queue *Queue) createQueueAndBind(routingKey string) error {
 	queueName := queue.queueNameByRoutingKey(routingKey)
-	err := queue.createQueue(queueName)
+	err := queue.createDeadLetterTopology()
+	if err != nil {
+		return err
+	}
+	err = queue.createQueue(queueName)
+	if err != nil {
+		return err
+	}
+	err = queue.createRetryQueue(queueName)
 	if err != nil {
 		return err
 	}

--- a/lib/event_people/rabbit_queue_test.go
+++ b/lib/event_people/rabbit_queue_test.go
@@ -1,0 +1,30 @@
+package EventPeople
+
+import "testing"
+
+func TestMainQueueArgs(t *testing.T) {
+	t.Setenv("RABBIT_EVENT_PEOPLE_APP_NAME", "sophia")
+
+	args := mainQueueArgs()
+	if got := args["x-dead-letter-exchange"]; got != "sophia.dlx" {
+		t.Errorf("x-dead-letter-exchange = %v, want sophia.dlx", got)
+	}
+	if len(args) != 1 {
+		t.Errorf("unexpected extra args: %v", args)
+	}
+}
+
+func TestRetryQueueArgs(t *testing.T) {
+	t.Setenv("RABBIT_EVENT_PEOPLE_RETRY_TTL_MS", "5000")
+
+	args := retryQueueArgs("sophia-resource.event.action.all")
+	if got := args["x-message-ttl"]; got != int64(5000) {
+		t.Errorf("x-message-ttl = %v (%T), want 5000 (int64)", got, got)
+	}
+	if got := args["x-dead-letter-exchange"]; got != "" {
+		t.Errorf("x-dead-letter-exchange = %v, want default exchange (empty)", got)
+	}
+	if got := args["x-dead-letter-routing-key"]; got != "sophia-resource.event.action.all" {
+		t.Errorf("x-dead-letter-routing-key = %v, want original queue name", got)
+	}
+}


### PR DESCRIPTION
## Problem

Consumers have only two failure outcomes, both bad:

- `Fail()` → `Nack(requeue=true)` → infinite redelivery for deterministic errors (poison message — see SOPHIA-1G: 1000 occurrences in 45 min from a single bad event).
- `Reject()` → `Reject(requeue=false)` with no DLX → message silently dropped.

Queue declaration (`rabbit_queue.go`) passes no arguments, so there is no `x-dead-letter-exchange` anywhere.

## Solution

- Declare a per-app fanout DLX (`<app>.dlx`) bound to a parking DLQ (`<app>.dlq`); main queues now declare `x-dead-letter-exchange` pointing at it. Any `Nack(requeue=false)`/`Reject(false)` is parked, never lost.
- `Fail()` becomes a bounded retry: republish to a per-queue TTL retry queue (`<queue>.retry`, returns to the original queue via the default exchange) with an `x-event-people-retries` counter; after `RABBIT_EVENT_PEOPLE_MAX_RETRIES` (default 3) — or if republish fails — dead-letter to the DLQ.
- `Reject()` keeps `requeue=false`, which now parks in the DLQ instead of discarding.
- New env vars: `RABBIT_EVENT_PEOPLE_MAX_RETRIES` (default 3), `RABBIT_EVENT_PEOPLE_RETRY_TTL_MS` (default 30000).
- Public `ContextInterface` unchanged — Sophia/Core/auth-people get the new behavior with only a version bump.
- First unit tests in the lib (`dlq_config`, queue args, retry decision table).

## Rollout (IMPORTANT)

Existing durable queues were declared without args; redeclaring with the DLX arg fails with `PRECONDITION_FAILED`. Per service: stop consumer → drain → delete queues → deploy. Documented in the README.

Shortcut: sc-22500 (https://app.shortcut.com/pinpeople/story/22500)

After merge: tag `v0.2.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dead Letter Queue (DLQ) support for handling failed messages with configurable retry logic.
  * Implemented bounded retries for transient errors, with automatic dead-lettering when retry limits are exhausted.
  * Added environment variable configuration for retry count and message TTL.

* **Documentation**
  * Enhanced README with detailed DLQ/retry topology documentation, runtime semantics, and operational guidance for DLQ inspection and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->