### PR TITLE
fix(BUG-GO-002): set event name from routing key, not AppName header

### DIFF
--- a/lib/event_people/context.go
+++ b/lib/event_people/context.go
@@ -17,4 +17,5 @@ type DeliveryStruct struct {
 	DeliveryInterface
 	DeliveryTag uint64
 	Body        []byte
+	RoutingKey  string
 }

--- a/lib/event_people/delivery_job.go
+++ b/lib/event_people/delivery_job.go
@@ -16,7 +16,7 @@ func (j *Job) Do() {
 	var eventMessage Event
 	json.Unmarshal(j.job.delivery.Body, &eventMessage)
 
-	eventMessage.Name = eventMessage.Headers.AppName
+	eventMessage.Name = j.job.delivery.RoutingKey
 	eventMessage.SchemaVersion = eventMessage.Headers.SchemaVersion
 
 	rabbitContext := NewContext(j.job.delivery.DeliveryInterface)

--- a/lib/event_people/rabbit_broker.go
+++ b/lib/event_people/rabbit_broker.go
@@ -96,9 +96,9 @@ func (rabbit *RabbitBroker) Consume(eventName string, callback Callback) {
 		var eventMessage Event
 		json.Unmarshal(delivery.Body, &eventMessage)
 
-		eventMessage.Name = eventMessage.Headers.AppName
+		eventMessage.Name = delivery.RoutingKey
 		eventMessage.SchemaVersion = eventMessage.Headers.SchemaVersion
-		deliveryStruct := DeliveryStruct{DeliveryInterface: delivery, Body: delivery.Body, DeliveryTag: delivery.DeliveryTag}
+		deliveryStruct := DeliveryStruct{DeliveryInterface: delivery, Body: delivery.Body, DeliveryTag: delivery.DeliveryTag, RoutingKey: delivery.RoutingKey}
 		rabbitContext := NewContext(delivery)
 		rabbitContext.DeliveryStruct = deliveryStruct
 		callback(eventMessage, rabbitContext)


### PR DESCRIPTION
## Problem

In the message callback, after unmarshalling the delivery body:

```go
eventMessage.Name = eventMessage.Headers.AppName
```

This overwrote the event name with the AppName string (e.g. `"myapp"`) on **every received message**. All listener callbacks received an event whose `.Name` was the app name instead of the actual event name (e.g. `user.auth.created.all`).

The bug was present in **two files**, not just one:
- `lib/event_people/rabbit_broker.go` (line 99)
- `lib/event_people/delivery_job.go` (line 19)

## Fix

Replaced both occurrences with `delivery.RoutingKey`. Added a `RoutingKey` field to `DeliveryStruct` in `context.go` to support the `delivery_job.go` code path.

## References
- Bug ID: `BUG-GO-002` in `.event_people.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)