### PR TITLE
fix: nack(requeue=false) on retry-publish failure

### DIFF
--- a/.event_people.yml
+++ b/.event_people.yml
@@ -1,5 +1,5 @@
-spec_version: "1.1.0"
-implementation_version: "v0.3.0"
+spec_version: "1.1.1"
+implementation_version: "v0.3.1"
 language: go
 package: "github.com/pinpeople/event_people_go"
 status: stable

--- a/lib/event_people/emitter.go
+++ b/lib/event_people/emitter.go
@@ -7,10 +7,10 @@ import (
 func TriggerEmitter(events []*Event) {
 	for index, event := range events {
 		if event.Body == "" {
-			log.Println("MissingAttributeError: Event on position %d must have a body", index)
+			log.Printf("MissingAttributeError: Event on position %d must have a body", index)
 		}
 		if event.Name == "" {
-			log.Println("MissingAttributeError: Event on position %d must have a name", index)
+			log.Printf("MissingAttributeError: Event on position %d must have a name", index)
 		}
 	}
 	for _, event := range events {

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -63,7 +63,7 @@ func (context *RabbitContext) Fail() {
 				return
 			}
 		} else {
-			log.Println("No channel available for retry publish; falling back to nack+requeue")
+			log.Println("No channel available for retry publish; falling back to nack without requeue (→ DLQ)")
 			context.delivery.Nack(false, false)
 			return
 		}

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -15,6 +15,7 @@ type RabbitContext struct {
 	MaxRetries     int
 	DLQName        string
 	channel        *amqp.Channel
+	publishFn      func(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
 	initialDelay   int // resolved once at construction time from RABBIT_EVENT_PEOPLE_RETRY_TTL_MS
 }
 
@@ -44,8 +45,8 @@ func (context *RabbitContext) Fail() {
 		retryQueueName := queueName + "_retry"
 		delay := rm.GetNextDelay(retryCount)
 
-		if context.channel != nil {
-			err := context.channel.Publish(
+		if context.publishFn != nil {
+			err := context.publishFn(
 				"",              // default exchange
 				retryQueueName, // routing key = retry queue name
 				false,
@@ -100,6 +101,7 @@ func NewContextWithRetry(delivery DeliveryInterface, channel *amqp.Channel, queu
 		MaxRetries:   maxRetries,
 		DLQName:      appName + "_dlq",
 		channel:      channel,
+		publishFn:    channel.Publish,
 		initialDelay: resolveInitialDelay(),
 	}
 	ctx.DeliveryStruct.MaxRetries = maxRetries

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -59,12 +59,12 @@ func (context *RabbitContext) Fail() {
 			)
 			if err != nil {
 				log.Printf("Failed to publish to retry queue: %v", err)
-				context.delivery.Nack(false, true)
+				context.delivery.Nack(false, false)
 				return
 			}
 		} else {
 			log.Println("No channel available for retry publish; falling back to nack+requeue")
-			context.delivery.Nack(false, true)
+			context.delivery.Nack(false, false)
 			return
 		}
 		context.delivery.Ack(false)

--- a/lib/event_people/rabbit_context_test.go
+++ b/lib/event_people/rabbit_context_test.go
@@ -1,0 +1,104 @@
+package EventPeople
+
+import (
+	"errors"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// fakeDelivery records the last Ack/Nack call made by RabbitContext.
+type fakeDelivery struct {
+	ackCalled    bool
+	nackCalled   bool
+	nackMultiple bool
+	nackRequeue  bool
+}
+
+func (f *fakeDelivery) Ack(multiple bool) error {
+	f.ackCalled = true
+	return nil
+}
+
+func (f *fakeDelivery) Nack(multiple, requeue bool) error {
+	f.nackCalled = true
+	f.nackMultiple = multiple
+	f.nackRequeue = requeue
+	return nil
+}
+
+func (f *fakeDelivery) Reject(requeue bool) error { return nil }
+
+func publishErr(_, _ string, _, _ bool, _ amqp.Publishing) error {
+	return errors.New("broker unavailable")
+}
+
+func publishOK(_, _ string, _, _ bool, _ amqp.Publishing) error { return nil }
+
+func baseCtx(d *fakeDelivery, retryCount, maxRetries int) *RabbitContext {
+	ctx := &RabbitContext{
+		delivery:     d,
+		MaxRetries:   maxRetries,
+		initialDelay: 1000,
+	}
+	ctx.DeliveryStruct.RetryCount = retryCount
+	ctx.DeliveryStruct.DelayStrategy = "exponential"
+	ctx.DeliveryStruct.QueueName = "test_queue"
+	ctx.DeliveryStruct.MaxRetries = maxRetries
+	return ctx
+}
+
+// TestFail_NilPublishFn_NacksWithoutRequeue: no channel configured → DLQ via nack(false,false).
+func TestFail_NilPublishFn_NacksWithoutRequeue(t *testing.T) {
+	d := &fakeDelivery{}
+	ctx := baseCtx(d, 0, 3) // retries remain, but publishFn is nil
+	ctx.Fail()
+	if !d.nackCalled || d.nackMultiple || d.nackRequeue {
+		t.Errorf("expected Nack(false, false); got nackCalled=%v multiple=%v requeue=%v",
+			d.nackCalled, d.nackMultiple, d.nackRequeue)
+	}
+	if d.ackCalled {
+		t.Error("Ack must not be called when publishFn is nil")
+	}
+}
+
+// TestFail_PublishError_NacksWithoutRequeue: broker error → DLQ via nack(false,false), not requeue.
+func TestFail_PublishError_NacksWithoutRequeue(t *testing.T) {
+	d := &fakeDelivery{}
+	ctx := baseCtx(d, 0, 3)
+	ctx.publishFn = publishErr
+	ctx.Fail()
+	if !d.nackCalled || d.nackMultiple || d.nackRequeue {
+		t.Errorf("expected Nack(false, false); got nackCalled=%v multiple=%v requeue=%v",
+			d.nackCalled, d.nackMultiple, d.nackRequeue)
+	}
+	if d.ackCalled {
+		t.Error("Ack must not be called on publish failure")
+	}
+}
+
+// TestFail_RetriesExhausted_NacksWithoutRequeue: no retries left → DLQ via nack(false,false).
+func TestFail_RetriesExhausted_NacksWithoutRequeue(t *testing.T) {
+	d := &fakeDelivery{}
+	ctx := baseCtx(d, 3, 3) // retryCount == maxRetries
+	ctx.publishFn = publishOK
+	ctx.Fail()
+	if !d.nackCalled || d.nackMultiple || d.nackRequeue {
+		t.Errorf("expected Nack(false, false); got nackCalled=%v multiple=%v requeue=%v",
+			d.nackCalled, d.nackMultiple, d.nackRequeue)
+	}
+}
+
+// TestFail_PublishSuccess_Acks: publish succeeds → ack the original delivery.
+func TestFail_PublishSuccess_Acks(t *testing.T) {
+	d := &fakeDelivery{}
+	ctx := baseCtx(d, 0, 3)
+	ctx.publishFn = publishOK
+	ctx.Fail()
+	if !d.ackCalled {
+		t.Error("expected Ack after successful retry publish")
+	}
+	if d.nackCalled {
+		t.Error("Nack must not be called on successful retry publish")
+	}
+}


### PR DESCRIPTION
When publishing to the retry queue fails, fall back to nack(requeue=false) instead of nack(requeue=true). Requeuing without incrementing x-event-people-retries causes an infinite redelivery loop (SOPHIA-1G). Implements spec v1.1.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error handling in message processing: messages no longer requeue when retry publishing fails.

* **Chores**
  * Version bumps: spec 1.1.0 → 1.1.1, implementation v0.3.0 → v0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->