### PR TITLE
[sc-22500] events: app-level DLQ (drop immutable x-dead-letter-exchange arg)

### DIFF
--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -76,8 +76,19 @@ func (context *RabbitContext) Fail() {
 		}
 		context.delivery.Ack(false)
 	} else {
-		// Exhausted retries — send to DLQ via nack without requeue (DLX will route to DLQ)
-		context.delivery.Nack(false, false)
+		// Exhausted retries — route the message to the application-level DLQ
+		// (a plain <app>_dlq queue) and ack the original delivery.
+		if context.channel == nil {
+			log.Println("No channel available for DLQ publish on exhaustion; falling back to nack")
+			context.delivery.Nack(false, false)
+			return
+		}
+		if err := context.publishToDLQ(); err != nil {
+			log.Printf("Failed to publish to DLQ on retry exhaustion: %v", err)
+			context.delivery.Nack(false, false)
+			return
+		}
+		context.delivery.Ack(false)
 	}
 }
 

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -8,13 +8,20 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
+// amqpPublisher is the narrow slice of *amqp.Channel that the context needs to
+// publish messages (to the retry queue and to the DLQ). Declaring it as an
+// interface keeps the publish paths unit-testable with a fake.
+type amqpPublisher interface {
+	Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
+}
+
 type RabbitContext struct {
 	ContextInterface
 	delivery       DeliveryInterface
 	DeliveryStruct DeliveryStruct
 	MaxRetries     int
 	DLQName        string
-	channel        *amqp.Channel
+	channel        amqpPublisher
 	initialDelay   int // resolved once at construction time from RABBIT_EVENT_PEOPLE_RETRY_TTL_MS
 }
 
@@ -74,9 +81,40 @@ func (context *RabbitContext) Fail() {
 	}
 }
 
-// Reject nacks without requeue, triggering DLX → DLQ routing.
+// Reject routes the message straight to the application-level DLQ (a plain
+// <app>_dlq queue) and acks the original delivery. This follows the EventPeople
+// spec (§C): the library routes to its own DLQ instead of relying on RabbitMQ's
+// broker-side dead-letter-exchange. With no x-dead-letter-exchange argument on
+// the main queue, library upgrades stay drop-in (no PRECONDITION_FAILED).
 func (context RabbitContext) Reject() {
-	context.delivery.Nack(false, false)
+	if context.channel == nil {
+		// No channel to publish with — fall back to a plain nack without requeue.
+		log.Println("No channel available for DLQ publish on Reject; falling back to nack")
+		context.delivery.Nack(false, false)
+		return
+	}
+	if err := context.publishToDLQ(); err != nil {
+		log.Printf("Failed to publish to DLQ on Reject: %v", err)
+		context.delivery.Nack(false, false)
+		return
+	}
+	context.delivery.Ack(false)
+}
+
+// publishToDLQ forwards the current message body to the application-level DLQ
+// via the default exchange (routing key = DLQ name).
+func (context RabbitContext) publishToDLQ() error {
+	return context.channel.Publish(
+		"",              // default exchange
+		context.DLQName, // routing key = DLQ queue name
+		false,
+		false,
+		amqp.Publishing{
+			Body:        context.DeliveryStruct.Body,
+			ContentType: context.DeliveryStruct.ContentType,
+			Headers:     amqp.Table{"x-event-people-retries": int32(context.DeliveryStruct.RetryCount)},
+		},
+	)
 }
 
 // NewContext creates a RabbitContext with delivery only (no retry config).

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -38,7 +38,8 @@ func (context RabbitContext) Success() {
 	context.delivery.Ack(false)
 }
 
-// Fail publishes the message to the retry queue if retries remain, otherwise Nacks without requeue.
+// Fail publishes the message to the retry queue if retries remain; once retries
+// are exhausted it publishes the message to the application-level DLQ and acks.
 func (context *RabbitContext) Fail() {
 	retryCount := context.DeliveryStruct.RetryCount
 	maxRetries := context.MaxRetries

--- a/lib/event_people/rabbit_context_test.go
+++ b/lib/event_people/rabbit_context_test.go
@@ -1,0 +1,82 @@
+package EventPeople
+
+import (
+	"os"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// ----------------------------------------------------------------------------
+// Test doubles
+// ----------------------------------------------------------------------------
+
+type publishedMsg struct {
+	exchange string
+	key      string
+	msg      amqp.Publishing
+}
+
+type fakePublisher struct {
+	published []publishedMsg
+	err       error
+}
+
+func (f *fakePublisher) Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
+	f.published = append(f.published, publishedMsg{exchange: exchange, key: key, msg: msg})
+	return f.err
+}
+
+type fakeDelivery struct {
+	acked       bool
+	nacked      bool
+	nackRequeue bool
+}
+
+func (d *fakeDelivery) Ack(multiple bool) error          { d.acked = true; return nil }
+func (d *fakeDelivery) Nack(multiple, requeue bool) error { d.nacked = true; d.nackRequeue = requeue; return nil }
+func (d *fakeDelivery) Reject(requeue bool) error         { return nil }
+
+// ----------------------------------------------------------------------------
+// Reject — app-level DLQ routing (spec §C: route to a plain <app>_dlq queue)
+// ----------------------------------------------------------------------------
+
+func TestReject_PublishesToDLQAndAcks(t *testing.T) {
+	os.Setenv("RABBIT_EVENT_PEOPLE_APP_NAME", "sophia")
+	defer os.Unsetenv("RABBIT_EVENT_PEOPLE_APP_NAME")
+
+	pub := &fakePublisher{}
+	del := &fakeDelivery{}
+	ctx := &RabbitContext{
+		delivery: del,
+		DLQName:  "sophia_dlq",
+		channel:  pub,
+	}
+	ctx.DeliveryStruct.Body = []byte(`{"x":1}`)
+	ctx.DeliveryStruct.ContentType = "application/json"
+
+	ctx.Reject()
+
+	if len(pub.published) != 1 {
+		t.Fatalf("Reject: expected 1 publish to DLQ, got %d", len(pub.published))
+	}
+	p := pub.published[0]
+	if p.exchange != "" {
+		t.Errorf("Reject: expected default exchange \"\", got %q", p.exchange)
+	}
+	if p.key != "sophia_dlq" {
+		t.Errorf("Reject: expected routing key sophia_dlq, got %q", p.key)
+	}
+	if string(p.msg.Body) != `{"x":1}` {
+		t.Errorf("Reject: expected body forwarded, got %q", string(p.msg.Body))
+	}
+	if p.msg.ContentType != "application/json" {
+		t.Errorf("Reject: expected content-type forwarded, got %q", p.msg.ContentType)
+	}
+	if !del.acked {
+		t.Errorf("Reject: expected Ack after DLQ publish")
+	}
+	if del.nacked {
+		t.Errorf("Reject: expected no Nack (DLX-based routing removed)")
+	}
+}

--- a/lib/event_people/rabbit_context_test.go
+++ b/lib/event_people/rabbit_context_test.go
@@ -80,3 +80,76 @@ func TestReject_PublishesToDLQAndAcks(t *testing.T) {
 		t.Errorf("Reject: expected no Nack (DLX-based routing removed)")
 	}
 }
+
+// ----------------------------------------------------------------------------
+// Fail — exhausted retries route to the app-level DLQ (not Nack→DLX)
+// ----------------------------------------------------------------------------
+
+func TestFail_ExhaustedPublishesToDLQAndAcks(t *testing.T) {
+	os.Setenv("RABBIT_EVENT_PEOPLE_APP_NAME", "sophia")
+	defer os.Unsetenv("RABBIT_EVENT_PEOPLE_APP_NAME")
+
+	pub := &fakePublisher{}
+	del := &fakeDelivery{}
+	ctx := &RabbitContext{
+		delivery:     del,
+		DLQName:      "sophia_dlq",
+		channel:      pub,
+		MaxRetries:   3,
+		initialDelay: 1000,
+	}
+	ctx.DeliveryStruct.Body = []byte(`{"x":1}`)
+	ctx.DeliveryStruct.ContentType = "application/json"
+	ctx.DeliveryStruct.QueueName = "sophia-resource.core.created.all"
+	ctx.DeliveryStruct.DelayStrategy = "exponential"
+	ctx.DeliveryStruct.RetryCount = 3 // == MaxRetries → exhausted
+
+	ctx.Fail()
+
+	if len(pub.published) != 1 {
+		t.Fatalf("Fail (exhausted): expected 1 publish to DLQ, got %d", len(pub.published))
+	}
+	p := pub.published[0]
+	if p.exchange != "" || p.key != "sophia_dlq" {
+		t.Errorf("Fail (exhausted): expected publish to default exchange/sophia_dlq, got %q/%q", p.exchange, p.key)
+	}
+	if !del.acked {
+		t.Errorf("Fail (exhausted): expected Ack after DLQ publish")
+	}
+	if del.nacked {
+		t.Errorf("Fail (exhausted): expected no Nack (DLQ publish replaces Nack→DLX)")
+	}
+}
+
+// Regression guard: with retries remaining, Fail still republishes to <queue>_retry.
+func TestFail_WithRetriesRepublishesToRetryQueue(t *testing.T) {
+	os.Setenv("RABBIT_EVENT_PEOPLE_APP_NAME", "sophia")
+	defer os.Unsetenv("RABBIT_EVENT_PEOPLE_APP_NAME")
+
+	pub := &fakePublisher{}
+	del := &fakeDelivery{}
+	ctx := &RabbitContext{
+		delivery:     del,
+		DLQName:      "sophia_dlq",
+		channel:      pub,
+		MaxRetries:   3,
+		initialDelay: 1000,
+	}
+	ctx.DeliveryStruct.Body = []byte(`{"x":1}`)
+	ctx.DeliveryStruct.QueueName = "sophia-resource.core.created.all"
+	ctx.DeliveryStruct.DelayStrategy = "exponential"
+	ctx.DeliveryStruct.RetryCount = 0 // retries remain
+
+	ctx.Fail()
+
+	if len(pub.published) != 1 {
+		t.Fatalf("Fail (retry): expected 1 publish to retry queue, got %d", len(pub.published))
+	}
+	p := pub.published[0]
+	if p.key != "sophia-resource.core.created.all_retry" {
+		t.Errorf("Fail (retry): expected publish to <queue>_retry, got %q", p.key)
+	}
+	if !del.acked {
+		t.Errorf("Fail (retry): expected Ack after retry publish")
+	}
+}

--- a/lib/event_people/rabbit_queue.go
+++ b/lib/event_people/rabbit_queue.go
@@ -18,13 +18,25 @@ type QueueInterface interface {
 	callback()
 }
 
+// amqpChannel is the slice of *amqp.Channel that Queue relies on. Declaring it
+// as an interface keeps the queue-declaration path unit-testable with a fake.
+type amqpChannel interface {
+	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
+	QueueInspect(name string) (amqp.Queue, error)
+	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error
+	ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error
+	ExchangeDeclarePassive(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error
+	Qos(prefetchCount, prefetchSize int, global bool) error
+	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
+}
+
 type Queue struct {
 	amqpQueue *amqp.Queue
-	channel   *amqp.Channel
+	channel   amqpChannel
 	QueueInterface
 }
 
-func (queue *Queue) Init(channel *amqp.Channel) {
+func (queue *Queue) Init(channel amqpChannel) {
 	queue.channel = channel
 }
 
@@ -54,13 +66,12 @@ func (queue *Queue) QueueName(routingKey string) string {
 }
 
 func (queue *Queue) createQueue(queueName string) error {
-	appName := os.Getenv("RABBIT_EVENT_PEOPLE_APP_NAME")
-	dlxName := appName + "_dlx"
-
-	args := amqp.Table{
-		"x-dead-letter-exchange": dlxName,
-	}
-	localQueue, err := queue.channel.QueueDeclare(queueName, true, false, false, false, args)
+	// The main queue is declared WITHOUT a dead-letter-exchange argument.
+	// Dead-lettering is handled at the application level (see RabbitContext:
+	// Reject and retry exhaustion publish to <app>_dlq). Keeping the main queue
+	// argument-free means upgrades over legacy queues never hit
+	// PRECONDITION_FAILED on redeclare.
+	localQueue, err := queue.channel.QueueDeclare(queueName, true, false, false, false, nil)
 	if err != nil {
 		return err
 	}
@@ -91,31 +102,17 @@ func (queue *Queue) exchangeBind(queueName string, routingKey string) error {
 	return nil
 }
 
-// declareDLXTopology declares the DLX exchange and DLQ (idempotent).
-func (queue *Queue) declareDLXTopology() error {
+// declareDLQ declares the application-level dead-letter queue (idempotent).
+// It is a plain durable queue, not bound to any dead-letter-exchange: the
+// library publishes failed messages to it directly (see RabbitContext). No DLX
+// fanout exchange or binding is created, so there is no broker-side topology to
+// drift between library versions.
+func (queue *Queue) declareDLQ() error {
 	appName := os.Getenv("RABBIT_EVENT_PEOPLE_APP_NAME")
-	dlxName := appName + "_dlx"
 	dlqName := appName + "_dlq"
 
-	// Declare DLX as a fanout exchange
-	err := queue.channel.ExchangeDeclare(dlxName, "fanout", true, false, false, false, nil)
-	if err != nil {
-		return err
-	}
-
-	// Declare DLQ
-	_, err = queue.channel.QueueDeclare(dlqName, true, false, false, false, nil)
-	if err != nil {
-		return err
-	}
-
-	// Bind DLQ to DLX with empty routing key
-	err = queue.channel.QueueBind(dlqName, "", dlxName, false, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := queue.channel.QueueDeclare(dlqName, true, false, false, false, nil)
+	return err
 }
 
 // declareRetryQueue declares the retry queue for a given main queue name (idempotent).
@@ -136,8 +133,8 @@ func (queue *Queue) declareRetryQueue(queueName string) error {
 func (queue *Queue) createQueueAndBind(routingKey string) error {
 	queueName := queue.queueNameByRoutingKey(routingKey)
 
-	// Declare DLX topology first (idempotent)
-	err := queue.declareDLXTopology()
+	// Declare the application-level DLQ first (idempotent)
+	err := queue.declareDLQ()
 	if err != nil {
 		return err
 	}

--- a/lib/event_people/rabbit_queue.go
+++ b/lib/event_people/rabbit_queue.go
@@ -145,7 +145,7 @@ func (queue *Queue) createQueueAndBind(routingKey string) error {
 		return err
 	}
 
-	// Declare main queue with dead-letter-exchange
+	// Declare the main queue (argument-free; dead-lettering is app-level)
 	err = queue.createQueue(queueName)
 	if err != nil {
 		return err

--- a/lib/event_people/rabbit_queue_test.go
+++ b/lib/event_people/rabbit_queue_test.go
@@ -1,0 +1,81 @@
+package EventPeople
+
+import (
+	"os"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// fakeChannel records declarations so we can assert the queue topology without
+// a live broker.
+type fakeChannel struct {
+	declaredQueues    map[string]amqp.Table // queue name -> declare args
+	declaredExchanges []string              // active (non-passive) exchange declares
+}
+
+func (f *fakeChannel) QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error) {
+	if f.declaredQueues == nil {
+		f.declaredQueues = map[string]amqp.Table{}
+	}
+	f.declaredQueues[name] = args
+	return amqp.Queue{Name: name}, nil
+}
+func (f *fakeChannel) QueueInspect(name string) (amqp.Queue, error) { return amqp.Queue{Name: name}, nil }
+func (f *fakeChannel) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
+	return nil
+}
+func (f *fakeChannel) ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error {
+	f.declaredExchanges = append(f.declaredExchanges, name)
+	return nil
+}
+func (f *fakeChannel) ExchangeDeclarePassive(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error {
+	return nil
+}
+func (f *fakeChannel) Qos(prefetchCount, prefetchSize int, global bool) error { return nil }
+func (f *fakeChannel) Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error) {
+	return nil, nil
+}
+
+// The main queue must be declared WITHOUT x-dead-letter-exchange so that
+// upgrading over legacy (arg-less) queues never triggers PRECONDITION_FAILED,
+// and the DLQ must be a plain queue (no broker dead-lettering topology).
+func TestCreateQueueAndBind_NoDLXArg_PlainDLQ(t *testing.T) {
+	os.Setenv("RABBIT_EVENT_PEOPLE_APP_NAME", "sophia")
+	os.Setenv("RABBIT_EVENT_PEOPLE_TOPIC_NAME", "pinpeople")
+	defer os.Unsetenv("RABBIT_EVENT_PEOPLE_APP_NAME")
+	defer os.Unsetenv("RABBIT_EVENT_PEOPLE_TOPIC_NAME")
+
+	fc := &fakeChannel{}
+	q := &Queue{channel: fc}
+
+	if err := q.createQueueAndBind("resource.core.created"); err != nil {
+		t.Fatalf("createQueueAndBind returned error: %v", err)
+	}
+
+	const mainQueue = "sophia-resource.core.created.all"
+	args, ok := fc.declaredQueues[mainQueue]
+	if !ok {
+		t.Fatalf("main queue %q was not declared; declared: %v", mainQueue, fc.declaredQueues)
+	}
+	if _, bad := args["x-dead-letter-exchange"]; bad {
+		t.Errorf("main queue must not declare x-dead-letter-exchange, got args %v", args)
+	}
+
+	dlqArgs, ok := fc.declaredQueues["sophia_dlq"]
+	if !ok {
+		t.Fatalf("DLQ sophia_dlq was not declared; declared: %v", fc.declaredQueues)
+	}
+	if dlqArgs != nil {
+		t.Errorf("DLQ must be a plain queue (nil args), got %v", dlqArgs)
+	}
+
+	if len(fc.declaredExchanges) != 0 {
+		t.Errorf("expected no active exchange declares (DLX fanout removed), got %v", fc.declaredExchanges)
+	}
+
+	// Retry queue is still declared (TTL backoff path is unchanged).
+	if _, ok := fc.declaredQueues[mainQueue+"_retry"]; !ok {
+		t.Errorf("retry queue %q_retry should still be declared", mainQueue)
+	}
+}


### PR DESCRIPTION
## What & why

Card: **sc-22821**. Follow-up to sc-22500.

Upgrading the library over queues created by an older version crash-looped the
consumer with `PRECONDITION_FAILED - inequivalent arg 'x-dead-letter-exchange'`:
the lib declared each main queue with the immutable `x-dead-letter-exchange`
argument, which can't be changed on an existing queue. The only remedy was a
destructive delete/recreate of every queue, in every environment.

This moves dead-lettering to the **application level** — which is what the
EventPeople spec §C always called for ("route to a regular DLQ queue, not the
broker's built-in DLX strategy"). The main queue is now declared **argument-free**,
so library upgrades are drop-in: no `PRECONDITION_FAILED`, no queue recreation, no
broker policy.

## Changes

- `Reject()` → publishes the message to a plain `<app>_dlq` (default exchange) and
  acks, instead of `Nack(false,false)` relying on a broker DLX.
- `Fail()` at retry exhaustion → same DLQ publish + ack (shared `publishToDLQ`).
- Main queue declared with `nil` args (no `x-dead-letter-exchange`); the DLX fanout
  exchange and its binding are removed; `<app>_dlq` is declared as a plain durable
  queue.
- Retry backoff path (`<queue>_retry`, per-message TTL → default exchange) is
  **unchanged**.
- Two narrow interface seams (`amqpPublisher`, `amqpChannel`) added so the publish
  and queue-declaration paths are unit-testable; `*amqp.Channel` satisfies both.

## Acceptance criteria

- [x] New lib over **argument-free** legacy queues → no `PRECONDITION_FAILED` / crash
- [x] Deterministic reject → `<app>_dlq` (no queue recreation)
- [x] Retry exhaustion → `<app>_dlq`
- [x] Transient error → `<queue>_retry` with exponential backoff, unchanged
- [x] No manual queue step on deploy (drop-in for the argument-free case)
- [x] Decision recorded in spec v1.1.1 + COMPATIBILITY.md (companion change in the
      `event_people` repo — see Deploy notes)

## Tests

`go test -vet=off ./...` green. New: `rabbit_context_test.go` (Reject→DLQ, exhaustion→DLQ,
retry-republish guard), `rabbit_queue_test.go` (no DLX arg on main queue, plain DLQ,
no fanout exchange, retry queue still declared).

> Note: `go test ./...` (vet on) trips a **pre-existing** `log.Println %d` warning in
> `emitter.go`, unrelated to this change.

## Deploy notes

- **Drop-in** when upgrading from an argument-free version (≤ v0.1.x): the redeclare
  is equivalent.
- **One-time cleanup** for any environment already on v0.2.0–v0.3.1 (queues carry the
  `x-dead-letter-exchange` arg): delete those main queues once before deploy, then they
  redeclare argument-free. See `COMPATIBILITY.md` in the `event_people` spec repo.
- Companion spec change (`event_people` v1.1.1 + COMPATIBILITY.md) is prepared on
  branch `sc-22821` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message failure handling to route exhausted messages to an application-level dead-letter queue instead of broker-based routing.
  * Modified rejection behavior to explicitly publish messages to the dead-letter queue with proper acknowledgment.

* **Tests**
  * Added comprehensive test coverage for message rejection and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->