### PR TITLE
[sc-22500] events: app-level DLQ (drop immutable x-dead-letter-exchange arg)

### DIFF
--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -105,8 +105,13 @@ func (ctx *RabbitContext) Fail() {
 	rm.CurrentAttempt = ctx.retryCount
 
 	if !rm.ShouldRetry() {
-		// Retries exhausted: nack(requeue=false) → DLX → DLQ.
-		ctx.delivery.Nack(false, false)
+		// Retries exhausted: publish the message to the application-level DLQ + ack.
+		if err := ctx.publishToDLQ(); err != nil {
+			fmt.Printf("EventPeople: failed to publish to DLQ %s on retry exhaustion: %v — nacking\n", ctx.DLQName, err)
+			ctx.delivery.Nack(false, false)
+			return
+		}
+		ctx.delivery.Ack(false)
 		return
 	}
 
@@ -159,5 +164,36 @@ func (ctx *RabbitContext) Fail() {
 
 // Reject rejects the event. Routes directly to DLQ without retrying (nack, requeue=false).
 func (ctx *RabbitContext) Reject() {
-	ctx.delivery.Reject(false)
+	if ctx.amqpChannel == nil || ctx.DLQName == "" {
+		ctx.delivery.Nack(false, false)
+		return
+	}
+	if err := ctx.publishToDLQ(); err != nil {
+		fmt.Printf("EventPeople: failed to publish to DLQ %s on Reject: %v — nacking\n", ctx.DLQName, err)
+		ctx.delivery.Nack(false, false)
+		return
+	}
+	ctx.delivery.Ack(false)
+}
+
+// publishToDLQ forwards the current message body to the application-level DLQ via
+// the default exchange (routing key = DLQ name), so failed messages are dead-lettered
+// without relying on a broker dead-letter-exchange.
+func (ctx *RabbitContext) publishToDLQ() error {
+	pubCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return ctx.amqpChannel.PublishWithContext(
+		pubCtx,
+		"",          // default exchange
+		ctx.DLQName, // routing key = DLQ queue name
+		false,
+		false,
+		amqp.Publishing{
+			DeliveryMode: amqp.Persistent,
+			Timestamp:    time.Now(),
+			ContentType:  ctx.DeliveryStruct.ContentType,
+			Body:         ctx.DeliveryStruct.Body,
+			Headers:      amqp.Table{"x-event-people-retries": int64(ctx.retryCount)},
+		},
+	)
 }

--- a/lib/event_people/rabbit_context.go
+++ b/lib/event_people/rabbit_context.go
@@ -182,6 +182,15 @@ func (ctx *RabbitContext) Reject() {
 func (ctx *RabbitContext) publishToDLQ() error {
 	pubCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	// The original message may not have its ContentType populated upstream.
+	// An empty ContentType produces an unparseable DLQ message, so fall back to
+	// the same value used by every other publish path in this implementation.
+	contentType := ctx.DeliveryStruct.ContentType
+	if contentType == "" {
+		contentType = "text/plain"
+	}
+
 	return ctx.amqpChannel.PublishWithContext(
 		pubCtx,
 		"",          // default exchange
@@ -191,7 +200,7 @@ func (ctx *RabbitContext) publishToDLQ() error {
 		amqp.Publishing{
 			DeliveryMode: amqp.Persistent,
 			Timestamp:    time.Now(),
-			ContentType:  ctx.DeliveryStruct.ContentType,
+			ContentType:  contentType,
 			Body:         ctx.DeliveryStruct.Body,
 			Headers:      amqp.Table{"x-event-people-retries": int64(ctx.retryCount)},
 		},

--- a/lib/event_people/rabbit_context_test.go
+++ b/lib/event_people/rabbit_context_test.go
@@ -11,6 +11,7 @@ import (
 // mockRetryPublisher satisfies retryPublisher and records what was published.
 type mockRetryPublisher struct {
 	published []amqp.Publishing
+	keys      []string
 	failWith  error
 }
 
@@ -24,6 +25,7 @@ func (m *mockRetryPublisher) PublishWithContext(
 		return m.failWith
 	}
 	m.published = append(m.published, msg)
+	m.keys = append(m.keys, key)
 	return nil
 }
 
@@ -81,15 +83,52 @@ func TestRabbitContextSuccess(t *testing.T) {
 	}
 }
 
-func TestRabbitContextReject(t *testing.T) {
+// Reject with no channel/DLQ configured falls back to nack(requeue=false).
+func TestRabbitContextRejectNoChannelNacks(t *testing.T) {
 	d := &mockDelivery{}
 	ctx := NewContext(d)
 	ctx.Reject()
-	if !d.rejected {
-		t.Error("expected Reject to be called")
+	if !d.nacked || d.requeue {
+		t.Error("expected Nack(requeue=false) fallback when no channel/DLQ is configured")
 	}
-	if d.requeue {
-		t.Error("expected requeue=false on Reject")
+}
+
+// Reject routes the message to the application-level DLQ (publish + ack), not a
+// broker dead-letter-exchange.
+func TestRabbitContextRejectPublishesToDLQ(t *testing.T) {
+	d := &mockDelivery{}
+	pub := &mockRetryPublisher{}
+	ctx := NewContextWithRetry(d, pub, "myqueue_retry", 0, 3, "myapp_dlq", 1000, "exponential")
+	ctx.DeliveryStruct = DeliveryStruct{Body: []byte(`{"x":1}`), ContentType: "application/json"}
+
+	ctx.Reject()
+
+	if len(pub.published) != 1 || pub.keys[0] != "myapp_dlq" {
+		t.Fatalf("Reject: expected 1 publish to myapp_dlq, got %d keys=%v", len(pub.published), pub.keys)
+	}
+	if string(pub.published[0].Body) != `{"x":1}` {
+		t.Errorf("Reject: expected body forwarded to DLQ, got %q", string(pub.published[0].Body))
+	}
+	if !d.acked || d.nacked {
+		t.Error("Reject: expected Ack after DLQ publish, no Nack")
+	}
+}
+
+// Retry exhaustion (with a channel) routes the message to the DLQ via publish + ack.
+func TestRabbitContextFailExhaustedPublishesToDLQ(t *testing.T) {
+	d := &mockDelivery{}
+	pub := &mockRetryPublisher{}
+	// retryCount=3, maxRetries=3 → exhausted; channel present → publish to DLQ.
+	ctx := NewContextWithRetry(d, pub, "myqueue_retry", 3, 3, "myapp_dlq", 1000, "exponential")
+	ctx.DeliveryStruct = DeliveryStruct{Body: []byte(`{}`)}
+
+	ctx.Fail()
+
+	if len(pub.published) != 1 || pub.keys[0] != "myapp_dlq" {
+		t.Fatalf("exhausted: expected 1 publish to myapp_dlq, got %d keys=%v", len(pub.published), pub.keys)
+	}
+	if !d.acked || d.nacked {
+		t.Error("exhausted: expected Ack after DLQ publish, no Nack")
 	}
 }
 

--- a/lib/event_people/rabbit_queue.go
+++ b/lib/event_people/rabbit_queue.go
@@ -18,13 +18,24 @@ type QueueInterface interface {
 	callback()
 }
 
+// amqpChannel is the slice of *amqp.Channel that Queue relies on. Declaring it as
+// an interface keeps the queue-declaration path unit-testable with a fake.
+type amqpChannel interface {
+	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
+	QueueInspect(name string) (amqp.Queue, error)
+	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error
+	ExchangeDeclarePassive(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error
+	Qos(prefetchCount, prefetchSize int, global bool) error
+	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
+}
+
 type Queue struct {
 	amqpQueue *amqp.Queue
-	channel   *amqp.Channel
+	channel   amqpChannel
 	QueueInterface
 }
 
-func (queue *Queue) Init(channel *amqp.Channel) {
+func (queue *Queue) Init(channel amqpChannel) {
 	queue.channel = channel
 }
 
@@ -54,13 +65,12 @@ func (queue *Queue) QueueName(routingKey string) string {
 }
 
 func (queue *Queue) createQueue(queueName string) error {
-	appName := os.Getenv("RABBIT_EVENT_PEOPLE_APP_NAME")
-	dlxName := appName + "_dlx"
-
-	args := amqp.Table{
-		"x-dead-letter-exchange": dlxName,
-	}
-	localQueue, err := queue.channel.QueueDeclare(queueName, true, false, false, false, args)
+	// The main queue is declared WITHOUT a dead-letter-exchange argument.
+	// Dead-lettering is handled at the application level (see RabbitContext:
+	// Reject and retry exhaustion publish to <app>_dlq). Keeping the main queue
+	// argument-free means upgrades over legacy queues never hit PRECONDITION_FAILED
+	// on redeclare.
+	localQueue, err := queue.channel.QueueDeclare(queueName, true, false, false, false, nil)
 	if err != nil {
 		return err
 	}
@@ -90,31 +100,17 @@ func (queue *Queue) exchangeBind(queueName string, routingKey string) error {
 	return nil
 }
 
-// declareDLXTopology declares the DLX exchange and DLQ (idempotent).
-func (queue *Queue) declareDLXTopology() error {
+// declareDLQ declares the application-level dead-letter queue (idempotent).
+// It is a plain durable queue, not bound to any dead-letter-exchange: the library
+// publishes failed messages to it directly (see RabbitContext). No DLX fanout
+// exchange or binding is created, so there is no broker-side topology to drift
+// between library versions.
+func (queue *Queue) declareDLQ() error {
 	appName := os.Getenv("RABBIT_EVENT_PEOPLE_APP_NAME")
-	dlxName := appName + "_dlx"
 	dlqName := appName + "_dlq"
 
-	// Declare DLX as a fanout exchange
-	err := queue.channel.ExchangeDeclare(dlxName, "fanout", true, false, false, false, nil)
-	if err != nil {
-		return err
-	}
-
-	// Declare DLQ
-	_, err = queue.channel.QueueDeclare(dlqName, true, false, false, false, nil)
-	if err != nil {
-		return err
-	}
-
-	// Bind DLQ to DLX with empty routing key
-	err = queue.channel.QueueBind(dlqName, "", dlxName, false, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err := queue.channel.QueueDeclare(dlqName, true, false, false, false, nil)
+	return err
 }
 
 // declareRetryQueue declares the retry queue for a given main queue name (idempotent).
@@ -135,8 +131,8 @@ func (queue *Queue) declareRetryQueue(queueName string) error {
 func (queue *Queue) createQueueAndBind(routingKey string) error {
 	queueName := queue.queueNameByRoutingKey(routingKey)
 
-	// Declare DLX topology first (idempotent)
-	err := queue.declareDLXTopology()
+	// Declare the application-level DLQ first (idempotent)
+	err := queue.declareDLQ()
 	if err != nil {
 		return err
 	}
@@ -147,7 +143,7 @@ func (queue *Queue) createQueueAndBind(routingKey string) error {
 		return err
 	}
 
-	// Declare main queue with dead-letter-exchange
+	// Declare the main queue (argument-free; dead-lettering is app-level)
 	err = queue.createQueue(queueName)
 	if err != nil {
 		return err

--- a/lib/event_people/rabbit_queue_test.go
+++ b/lib/event_people/rabbit_queue_test.go
@@ -3,7 +3,67 @@ package EventPeople
 import (
 	"os"
 	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
 )
+
+// fakeChannel records queue declarations so we can assert the topology without a broker.
+type fakeChannel struct {
+	declaredQueues map[string]amqp.Table
+}
+
+func (f *fakeChannel) QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error) {
+	if f.declaredQueues == nil {
+		f.declaredQueues = map[string]amqp.Table{}
+	}
+	f.declaredQueues[name] = args
+	return amqp.Queue{Name: name}, nil
+}
+func (f *fakeChannel) QueueInspect(name string) (amqp.Queue, error) { return amqp.Queue{Name: name}, nil }
+func (f *fakeChannel) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
+	return nil
+}
+func (f *fakeChannel) ExchangeDeclarePassive(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error {
+	return nil
+}
+func (f *fakeChannel) Qos(prefetchCount, prefetchSize int, global bool) error { return nil }
+func (f *fakeChannel) Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error) {
+	return nil, nil
+}
+
+// The main queue must be declared WITHOUT x-dead-letter-exchange (so upgrades over
+// legacy queues never PRECONDITION_FAIL), and the DLQ must be a plain queue.
+func TestCreateQueueAndBind_NoDLXArg_PlainDLQ(t *testing.T) {
+	os.Setenv("RABBIT_EVENT_PEOPLE_APP_NAME", "sophia")
+	os.Setenv("RABBIT_EVENT_PEOPLE_TOPIC_NAME", "pinpeople")
+	defer os.Unsetenv("RABBIT_EVENT_PEOPLE_APP_NAME")
+	defer os.Unsetenv("RABBIT_EVENT_PEOPLE_TOPIC_NAME")
+
+	fc := &fakeChannel{}
+	q := &Queue{channel: fc}
+	if err := q.createQueueAndBind("resource.core.created"); err != nil {
+		t.Fatalf("createQueueAndBind: %v", err)
+	}
+
+	const mainQueue = "sophia-resource.core.created.all"
+	args, ok := fc.declaredQueues[mainQueue]
+	if !ok {
+		t.Fatalf("main queue %q not declared; declared: %v", mainQueue, fc.declaredQueues)
+	}
+	if _, bad := args["x-dead-letter-exchange"]; bad {
+		t.Errorf("main queue must not declare x-dead-letter-exchange, got %v", args)
+	}
+	dlqArgs, ok := fc.declaredQueues["sophia_dlq"]
+	if !ok {
+		t.Fatalf("DLQ sophia_dlq not declared; declared: %v", fc.declaredQueues)
+	}
+	if dlqArgs != nil {
+		t.Errorf("DLQ must be a plain queue (nil args), got %v", dlqArgs)
+	}
+	if _, ok := fc.declaredQueues[mainQueue+"_retry"]; !ok {
+		t.Errorf("retry queue should still be declared")
+	}
+}
 
 func TestQueueNameByRoutingKeyThreeParts(t *testing.T) {
 	os.Setenv("RABBIT_EVENT_PEOPLE_APP_NAME", "myapp")


### PR DESCRIPTION
## What & why

Card: **sc-22500**. Upgrading the library over queues created by an older version
crash-looped the consumer with `PRECONDITION_FAILED - inequivalent arg
'x-dead-letter-exchange'`: the lib declared each main queue with that immutable
argument. This moves dead-lettering to the **application level** (spec §C): the main
queue is declared **argument-free**, and the library publishes failed messages to a
plain `<app>_dlq`. Upgrades become drop-in — no `PRECONDITION_FAILED`, no queue
recreation, no broker policy.

## Changes
- `Reject()` and retry-exhaustion → publish to `<app>_dlq` (default exchange) + ack,
  instead of `Nack(false,false)` relying on a broker DLX.
- Main queue declared with `nil` args; DLX fanout + binding removed; `<app>_dlq` is a
  plain durable queue.
- Retry backoff (`<queue>_retry`, per-message TTL) unchanged.
- `amqpPublisher` / `amqpChannel` seams for unit-testability.

## Tests
`go test -vet=off ./...` green (Reject→DLQ, exhaustion→DLQ, retry-republish guard, no
DLX arg on main queue, plain DLQ, no fanout). `vet`-on trips a pre-existing
`emitter.go` warning unrelated to this change.

## Notes
- Drop-in over argument-free (≤ v0.1.x) queues. One-time cleanup for envs on
  v0.2.0–v0.3.1 (arg-bearing queues) — see `COMPATIBILITY.md` in the `event_people`
  spec repo.
- Companion spec PR in `event_people`.
- Supersedes the broker-DLX (v0.3.x) mechanism. (Interim card sc-22821 was archived.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message handling so rejected/failed deliveries route to the application-level DLQ when appropriate, with retry count tracking, and use non-requeue NACKs if DLQ publishing isn’t available.
  * Simplified RabbitMQ topology by removing the intermediate dead-letter exchange usage for the main queue; the app DLQ is declared and used directly.

* **Tests**
  * Added/updated unit tests to verify DLQ publishing, ACK/NACK behavior across channel/DLQ availability, and the revised queue declaration expectations (including absence of DLX arguments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->